### PR TITLE
broken link: LF's telemetry policy doc has moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repo contains several documents and links related to the operation of the [
 * [Blog Guidelines](blog-guidelines.md)
 * [Webinars Guidelines](webinars-guidelines.md)
 * [Project Website guidelines](project-website-guidelines.md) for mentioning companies while maintaining neutrality
-* [Telemetry and Data Collection Policy](https://www.linuxfoundation.org/telemetry-data-policy/)
+* [Telemetry and Data Collection Policy](https://www.linuxfoundation.org/telemetry-data-collection-and-usage-policy/)
 * @TODO - [Whitelist policy](#) for which licenses are acceptable in upstream dependencies without requiring an explicit vote of the governing board
 
 ## Community recommendations


### PR DESCRIPTION
This is a simple url update to shift to the current location of the
Linux Foundation's telemetry data collection and usage policy.

Signed-off-by: Tim Pepper tpepper@vmware.com