### PR TITLE
remove whitelist reference in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repo contains several documents and links related to the operation of the [
 * [Webinars Guidelines](webinars-guidelines.md)
 * [Project Website guidelines](project-website-guidelines.md) for mentioning companies while maintaining neutrality
 * [Telemetry and Data Collection Policy](https://www.linuxfoundation.org/telemetry-data-collection-and-usage-policy/)
-* @TODO - [Whitelist policy](#) for which licenses are acceptable in upstream dependencies without requiring an explicit vote of the governing board
+* @TODO - [Allowlist policy](#) for which licenses are acceptable in upstream dependencies without requiring an explicit vote of the governing board
 
 ## Community recommendations
 


### PR DESCRIPTION
To have more inclusive naming in our repos it is recommended we remove all references to "whitelist" as per the inclusivenaming.org wordlists. This is the only reference in all the cdfoundation org repositories.

https://inclusivenaming.org/word-lists/tier-1/whitelist/

Signed-off-by: Brad McCoy <bradmccoydev@gmail.com>