### PR TITLE
Create CFP Review Guidelines

### DIFF
--- a/CDF CFP Review Guidelines.md
+++ b/CDF CFP Review Guidelines.md
@@ -1,0 +1,31 @@
+# CDF CFP Review Guidelines #
+
+## Overview ##
+
+The Continuous Delivery Foundation (CDF) holds a number of events each year such as cdCon and Continuous Delivery Summit.  A program committee will be formed for each event to review the Call For Proposals (CFP).  To ensure we meet the values of the CDF, this guideline is to help committee members review the CFP's so we can keep the events as diverse, inclusive and fair for all.
+
+Below are some best practices to consider when reviewing CFP's:
+* Gender
+* Experience
+* Conflict of Interest
+* Process Integrity
+* Public & Author Interaction
+* Review Comments
+
+## Gender ##
+Diversity is very important at events so please keep a good mix of different genders when selecting.
+
+## Experience ##
+Use your expert knowledge to assess the experience level for the audience to understand the presentation. If you feel the presentation is not the experience level the speaker indicated, please use this section in the form to indicate which experience would be a better fit.
+
+## Conflict of Interest ##
+Reviewers are asked to act as CDF community members, rather than the company or other affiliation when scoring submissions so that you rate all submissions fairly. If a submission was written by a colleague you work closely with or someone that you are seen to be associated with or in competition with, please skip by marking as a conflict of interest.
+
+## Process Integrity ##
+It is very important to protect the integrity of the review process, and to avoid undue bias, by keeping the submissions and your comments on them confidential.
+
+## Public & Author Interaction ##
+To ensure an unbiased review process, program committee members should not discuss submissions with authors and/or the overall public (i.e., please no tweeting). Of course, please feel free to tweet about accepted sessions that you are excited to attend once the schedule has been published.
+
+## Review Comments ##
+Keep in mind that submitting authors may be a VP at a large company or a university student. Ensure your feedback is constructive, in particular for rejected proposals, as we do receive requests for feedback and we may pass on some comments (though we would not associate them with you)


### PR DESCRIPTION
Create the start of CFP Review guidelines so we can collaborate with program committee members of CDF events.
 
Signed-off-by: Brad McCoy <bradmccoydev@gmail.com>